### PR TITLE
chore(deps): add maven dash plugin to keep DEPENDENCIES file up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ As with all Docker images, these likely also contain other software which may be
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
 
+## Updating the `DEPENDENCIES` file
+
+To update the [DEPENDENCIES](./DEPENDENCIES) declarations, run:
+
+```shell
+mvn org.eclipse.dash:license-tool-plugin:license-check 
+```
+
 ### For installation guide:
 
 [INSTALL.md](INSTALL.md)

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,24 @@
 					</compilerArgs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.dash</groupId>
+				<artifactId>license-tool-plugin</artifactId>
+				<version>0.0.1-SNAPSHOT</version>
+				<configuration>
+					<projectId>automotive.tractusx</projectId>
+					<summary>DEPENDENCIES</summary>
+					<includeScope>test</includeScope>
+				</configuration>
+				<executions>
+					<execution>
+						<id>license-check</id>
+						<goals>
+							<goal>license-check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -384,4 +384,13 @@
 			</snapshots>
 		</repository>
 	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>dash-licenses-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 </project>


### PR DESCRIPTION
## Description
This PR adds the maven Dash plugin to the pom.xml to provide an easy way to re-generate the `DEPENDENCIES` file