### PR TITLE
fix: veracode workflow update

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Set up JDK 18
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '18'
           distribution: 'temurin'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix link to temurin repository in "Notice for Docker images" (#90)
 - Remove default connection test, that prevented helm test to succeed (#92)
 - Fix Chart names in helm test step (#95)
+- Fixed veracode workflow by upgrading version
 
 
 ## [1.5.1] - 2023-11-17


### PR DESCRIPTION
- This PR fixes the workflow which is failing due to below issue.

_Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/