### PR TITLE
refactor: removal of catenax-ng reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,12 +301,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enable triggering of Autosetup process for SDE application
 - Enable triggering of Autosetup process for EDC application
 - Creation of the certificates for DAPS registration
-- Registration of EDC connector into Catena-X dataspace
+- Registration of EDC connector into CX dataspace
 - Registration of the services in CX-Portal
 - Autosetup process is based on KubeApps
 
 ### Changed
-- Integration to Catena-X Portal
+- Integration to CX Portal
 
 ### Known knowns
 - Cross side scripting (XSS) shall be mitigated (low risk)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Link to flyway documentation: [Documentation](https://flywaydb.org/documentation
 Authentication for the backend is handled via an Keycloak. This can be set in the configuration file.
 
 ### EDC
-GitHub repository with correct version of the Eclipse DataSpace Connector Project: [repository](https://github.com/catenax-ng/product-edc)
+GitHub repository with correct version of the Eclipse DataSpace Connector Project: [repository](https://github.com/eclipse-tractusx/tractusx-edc)
 
 ### Licenses
 Distributed under the Apache 2.0 License. See [LICENSE](LICENSE) for more information.

--- a/src/main/resources/flyway/V5__new_app_dt-registry.sql
+++ b/src/main/resources/flyway/V5__new_app_dt-registry.sql
@@ -42,7 +42,7 @@ VALUES('DT_REGISTRY', 'default', 'kubeapps', '{
 		"idpClientId" : "$\{idpClientId\}",
 		"idpIssuerUri": "$\{idpIssuerUri\}",
 		"tenantId" : "$\{tenantId\}",
-		"image" :"ghcr.io/catenax-ng/sldt-digital-twin-registry:0.3.1-M1",
+		"image" :"sldt-digital-twin-registry-image",
         "ingress": {
                 "enabled": true,
                 "hostname": "$\{dnsName\}",


### PR DESCRIPTION
With this PR we are removing the reference of catenax-ng from the repository.
- Fixes #189 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
