### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,12 +53,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.5.1
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
@@ -75,14 +75,14 @@ jobs:
 
       - name: DockerHub login
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.3.0
         with:
           # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.7.0
         with:
           context: .
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
@@ -94,7 +94,7 @@ jobs:
       # Important step to push image description to DockerHub 
       - name: Update Docker Hub description
         if: github.event_name != 'pull_request'
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.0
         with:
         # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
         # readme-filepath: path/to/dedicated/notice-for-docker-image.md 

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # fetch-depth: 0 is required to determine differences in chart(s)
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,6 +56,6 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,6 @@ on:
 jobs:
   analyze:
     name: Analyze
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
@@ -65,18 +60,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     #Setup Java 17
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.2.2
       with:
         java-version: '17'
         distribution: 'adopt'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.25.10
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -91,11 +86,10 @@ jobs:
 
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
+    # If this step step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-      #uses: github/codeql-action/autobuild@v3
+      #uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.25.10
 
-    # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
@@ -106,6 +100,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.25.10
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -46,29 +46,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Kubernetes KinD Cluster
-        uses: container-tools/kind-action@v2
+        uses: container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e # v2.0.4
         with:
           version: v0.20.0
           node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.24.6' }}
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.7.0
         with:
           context: .
           push: true
           tags: kind-registry:5000/managed-service-orchestrator:testing
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.2.0
         with:
           version: v3.10.3
 
       # Setup python as a prerequisite for chart linting
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.1.1
         with:
           python-version: '3.9'
           check-latest: true

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -43,10 +43,10 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: KICS scan
-        uses: checkmarx/kics-github-action@master
+        uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
         with:
           # Scanning directory .
           path: "."
@@ -68,6 +68,6 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.25.10
         with:
           sarif_file: kicsResults/results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -47,7 +47,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.25.10
         if: always()
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
## Description
This PR replaces all mutable GitHub Actions version references (e.g. `@master`, `@main`, and floating tags like `@v2`, `@v3`, `@v4`, `@v5`, `@v6`) in `.github/workflows/` with **immutable, SHA-pinned** references. This is a supply-chain security hardening measure.

### :warning: Why this matters
Using mutable version tags means your CI/CD pipeline silently executes **whatever code an action's maintainer - or an attacker who has compromised their account - pushes** to that branch or tag at any point in time. Pinning to a full 40-character commit SHA provides immutability and auditability.

### Changes introduced in this PR
The following action references in this repository have been replaced. A human-readable version comment is retained next to each SHA for maintainability.

| Workflow File | Old Reference | New SHA-Pinned Reference | Resolved Version |
| --- | --- | --- | --- |
| `.github/workflows/kics.yml` | `checkmarx/kics-github-action@master` | `checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6` | v2.1.20 |
| `.github/workflows/build.yaml` | `docker/metadata-action@v5` | `docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051` | v5.5.1 |
| `.github/workflows/build.yaml` | `docker/login-action@v3` | `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.3.0 |
| `.github/workflows/build.yaml` | `docker/build-push-action@v6` | `docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8` | v6.7.0 |
| `.github/workflows/codeql.yml` | `github/codeql-action/*@v3` | `github/codeql-action/*@dd903d2e4f5405488e5ef1422510ee31c8b32357` | v3.25.10 |
| `.github/workflows/chart-release.yml` | `azure/setup-helm@v4` | `azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4` | v4.2.0 |
| `.github/workflows/chart-release.yml` | `helm/chart-releaser-action@v1.6.0` | `helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584` | v1.6.0 |
| `.github/workflows/helm-lint.yaml` | `container-tools/kind-action@v2` | `container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e` | v2.0.4 |

## Pre-review checks
- [x] DEPENDENCIES are up-to-date.
- [x] Copyright and license header are present on all affected files